### PR TITLE
Change CODEOWNERS to use the SFCC-Unofficial-Admins team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @danechitoaie @Gektorian @gokaygurcan @matthewrose @sholsinger
+*   @sfcc-unofficial/SFCC-Unofficial-Admins


### PR DESCRIPTION
This means we won't need to update the file when members change. :)